### PR TITLE
Bump ansys-api-platform-instancemanagement dependency to the released version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,7 +137,7 @@ Integration
 -----------
 
 PyPIM can be integrated in PyAnsys libraries to transparently switch to a remote
-instance in a suitable environment. This process is described in `Integration <https://pypim.docs.pyansys.com/integration.html>`_
+instance in a suitable environment. This process is described in `Integration <https://pypim.docs.pyansys.com/version/dev/integration.html>`_
 in the PyPIM documentation.
 
 For example, starting MAPDL with PyPIM is as simple as using this code:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,12 +29,12 @@ classifiers = [
 ]
 dependencies = [
     "importlib-metadata >=4.0",
-    "ansys-api-platform-instancemanagement>=1.0.0b3",
+    "ansys-api-platform-instancemanagement~=1.0",
 ]
 
 [project.optional-dependencies]
 tests = [
-    "ansys-api-platform-instancemanagement>=1.0.0b1",
+    "ansys-api-platform-instancemanagement==1.0.0",
     "grpcio-health-checking==1.56.2",
     "grpcio-testing",
     "six~=1.16",
@@ -42,7 +42,7 @@ tests = [
     "pytest-cov==4.1.0",
 ]
 doc = [
-    "ansys-api-platform-instancemanagement>=1.0.0b1",
+    "ansys-api-platform-instancemanagement==1.0.0",
     "ansys-sphinx-theme==0.10.2",
     "numpydoc==1.5.0",
     "Sphinx==7.1.2",


### PR DESCRIPTION
`pypim` was declaring its dependency to ansys-api-platform-instancemanagement to be the beta version, bump it to the released version.

Also adjust the dependency format:
- pin for doc and test generation
- use the compatible operator for the declared dependency

Also fix a broken link in the documentation
