### PR TITLE
Revert "maint: bump the actions group with 1 update"

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: "Upload coverage to Codecov"
         if: matrix.python-version ==  ${{ env.MAIN_PYTHON_VERSION }} && matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
 
   build-library:
     name: "Build library"


### PR DESCRIPTION
Reverts ansys/pypim#107

codecov/codecov-action@v4 is not yet released.