### PR TITLE
fix: ignore linkcheck for MIT link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ PyPIM
     :alt: GitHub Workflow Status (branch)
 
 .. |MIT| image:: https://img.shields.io/badge/License-MIT-yellow.svg
-   :target: https://opensource.org/blog/license/mit
+   :target: https://opensource.org/licenses/MIT
    :alt: MIT License
 
 .. |black| image:: https://img.shields.io/badge/code%20style-black-000000.svg?style=flat

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ PyPIM
     :alt: GitHub Workflow Status (branch)
 
 .. |MIT| image:: https://img.shields.io/badge/License-MIT-yellow.svg
-   :target: https://opensource.org/licenses/MIT
+   :target: https://opensource.org/blog/license/mit
    :alt: MIT License
 
 .. |black| image:: https://img.shields.io/badge/code%20style-black-000000.svg?style=flat

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -96,3 +96,8 @@ source_suffix = ".rst"
 
 # The master toctree document.
 master_doc = "index"
+
+# Ignored links
+linkcheck_ignore = [
+    "https://opensource.org/licenses/MIT",
+]


### PR DESCRIPTION
The link to the MIT license, https://opensource.org/licenses/MIT, is broken so I replaced it with https://opensource.org/blog/license/mit

Example of where it broke in a workflow: https://github.com/ansys/pypim/actions/runs/11552124698/job/32214858961#step:2:1845